### PR TITLE
Update Docker Engine to 20.10.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update \
     && rm -rf /var/lib/apt/list/*
 
 ENV DOCKER_CHANNEL=stable \
-	DOCKER_VERSION=20.10.9 \
+	DOCKER_VERSION=20.10.17 \
 	DOCKER_COMPOSE_VERSION=1.29.2 \
 	DEBUG=false
 


### PR DESCRIPTION
We had a bug running Ubuntu 22.04 with the Docker Engine version provided by your image (related to `apt-get update` command), which doesn't happen on version 20.10.17.

Therefore, I recommend to upgrade to it.