### PR TITLE
Forward commands from `docker run`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ RUN curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOS
 	&& chmod +x /usr/local/bin/docker-compose && docker-compose version
 
 ENTRYPOINT ["startup.sh"]
-CMD ["sh"]
+CMD ["bash"]

--- a/startup.sh
+++ b/startup.sh
@@ -34,4 +34,4 @@ for process in "${processes[@]}"; do
 done
 
 # Wait processes to be running
-/bin/bash
+"$@"


### PR DESCRIPTION
Currently any commands given to docker run are ignored. This allows the user to specify their own commands, while defaulting to `bash` if no command is given.