### PR TITLE
Use iptables-legacy on noble and jammy

### DIFF
--- a/ubuntu-jammy.Dockerfile
+++ b/ubuntu-jammy.Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:22.04
 RUN apt update \
     && apt install -y ca-certificates \
     wget curl iptables supervisor \
-    && rm -rf /var/lib/apt/list/*
+    && rm -rf /var/lib/apt/list/* \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 ENV DOCKER_CHANNEL=stable \
 	DOCKER_VERSION=25.0.1 \

--- a/ubuntu-noble.Dockerfile
+++ b/ubuntu-noble.Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:24.04
 RUN apt update \
     && apt install -y ca-certificates \
     wget curl iptables supervisor \
-    && rm -rf /var/lib/apt/list/*
+    && rm -rf /var/lib/apt/list/* \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy
 
 ENV DOCKER_CHANNEL=stable \
 	DOCKER_VERSION=25.0.1 \


### PR DESCRIPTION
Previously, these images would fail to run on minikube with the kvm2 backend:

```
time="2024-01-27T05:16:39.578877539Z" level=info msg="Loading containers: start."
time="2024-01-27T05:16:39.582515691Z" level=info msg="unable to detect if iptables supports xlock: 'iptables --wait -L -n': `iptables v1.8.7 (nf_tables): Could not fetch rule set generation id: Invalid argument`" error="exit status 4"
```

If there's other host configurations that fix this, I will gladly close this PR and do that instead, but this fixes the issue with no side effects as far as I can tell.