### PR TITLE
Create ubuntu-dind.yaml

### DIFF
--- a/ubuntu-dind.yaml
+++ b/ubuntu-dind.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: docker-dind
+spec:
+  containers:
+  - name: ubuntu-dind
+    image: cruizba/ubuntu-dind:systemd-latest
+    args: ["sleep", "infinity"]
+    securityContext:
+      privileged: true
+  restartPolicy: Never


### PR DESCRIPTION
Adding a yaml if the user wants to deploy a container on k8s cluster with dind. 
This requirement came up while testing CVE https://www.wiz.io/blog/nvidia-ai-vulnerability-cve-2025-23266-nvidiascape 
I hope this can have other use cases also for other users in search of a DinD setup