### PR TITLE
fix: wait for Docker API ready

### DIFF
--- a/start-docker.sh
+++ b/start-docker.sh
@@ -17,6 +17,25 @@ function wait_for_process () {
     return 0
 }
 
+function wait_for_docker_api () {
+    local max_time_wait=30
+    local waited_sec=0
+
+    # dockerd may be running but not yet ready to accept API requests.
+    # Wait until the Docker API responds successfully to avoid race conditions
+    # with subsequent docker commands.
+    while ! docker info >/dev/null 2>&1 && ((waited_sec < max_time_wait)); do
+        INFO "Docker API is not ready yet. Retrying in 1 seconds"
+        INFO "Waited $waited_sec seconds of $max_time_wait seconds"
+        sleep 1
+        ((waited_sec=waited_sec+1))
+        if ((waited_sec >= max_time_wait)); then
+            return 1
+        fi
+    done
+    return 0
+}
+
 INFO "Starting supervisor"
 /usr/bin/supervisord -n >> /dev/null 2>&1 &
 
@@ -27,4 +46,13 @@ if [ $? -ne 0 ]; then
     exit 1
 else
     INFO "dockerd is running"
+fi
+
+INFO "Waiting for Docker API to become ready"
+wait_for_docker_api
+if [ $? -ne 0 ]; then
+    ERROR "Docker API did not become ready after max time"
+    exit 1
+else
+    INFO "Docker API is ready"
 fi


### PR DESCRIPTION
I am running a k3s and sometimes encounter the issue of: 
```
"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
```

I suspect that `pgrep` only confirms the dockerd process exists. In practice the daemon may still be initializing and not yet accepting connections on the Docker socket. Waiting for a successful `docker info` avoids intermittent failures in subsequent docker commands. 