### PR TITLE
Add GitHub Container Registry and Quay.io as image registries

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -41,6 +44,20 @@ jobs:
         with:
           username: cruizba
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Quay.io
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build standalone image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -76,6 +93,14 @@ jobs:
             cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
             cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-latest
             ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'cruizba/ubuntu-dind:latest' || '' }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-${{ env.CURRENT_VERSION }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-latest
+            ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'ghcr.io/cruizba/ubuntu-dind:latest' || '' }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-${{ env.CURRENT_VERSION }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-latest
+            ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'quay.io/cruizba/ubuntu-dind:latest' || '' }}
 
       - name: Build systemd image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -110,3 +135,11 @@ jobs:
             cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
             cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-latest
             ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'cruizba/ubuntu-dind:systemd-latest' || '' }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-${{ env.CURRENT_VERSION }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
+            ghcr.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-latest
+            ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'ghcr.io/cruizba/ubuntu-dind:systemd-latest' || '' }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-${{ env.CURRENT_VERSION }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-${{ env.CURRENT_VERSION }}-r${{ env.BUILD_NUMBER }}
+            quay.io/cruizba/ubuntu-dind:${{ matrix.ubuntu_name }}-systemd-latest
+            ${{ matrix.ubuntu_version == env.LATEST_UBUNTU_VERSION && 'quay.io/cruizba/ubuntu-dind:systemd-latest' || '' }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -90,7 +90,18 @@ jobs:
           Docker compose version: ${{ inputs.docker_compose_version }}
           Docker buildx: ${{ inputs.buildx_version }}
 
-          ## Dockerhub images
+          ## Available registries
+
+          Images are published to Docker Hub, GitHub Container Registry and Quay.io.
+          All registries publish the same tags — pull from whichever you prefer:
+
+          | Registry | Image |
+          |----------|-------|
+          | Docker Hub | `cruizba/ubuntu-dind` |
+          | GitHub Container Registry | `ghcr.io/cruizba/ubuntu-dind` |
+          | Quay.io | `quay.io/cruizba/ubuntu-dind` |
+
+          ## Updated images
 
           > Updated images
           ```bash
@@ -134,6 +145,8 @@ jobs:
           ```
           cruizba/ubuntu-dind:systemd-latest
           ```
+
+          > Prefix any tag with `ghcr.io/` or `quay.io/` to pull from those registries instead.
           EOF
 
       - name: Create Release

--- a/README.md
+++ b/README.md
@@ -174,8 +174,28 @@ You have this example in the `examples` folder.
 
 ## 5. Available images
 
-You can find the available images in the [Docker Hub](https://hub.docker.com/r/cruizba/ubuntu-dind).
+Images are published to three registries:
+
+| Registry | URL |
+|----------|-----|
+| Docker Hub | https://hub.docker.com/r/cruizba/ubuntu-dind |
+| GitHub Container Registry | https://github.com/cruizba/ubuntu-dind/pkgs/container/ubuntu-dind |
+| Quay.io | https://quay.io/repository/cruizba/ubuntu-dind |
+
 Check also the Releases section to see the available tags: [Releases](https://github.com/cruizba/ubuntu-dind/releases)
+
+All registries publish the same tags. You can pull from any of them by prefixing the image name:
+
+```bash
+# Docker Hub (default)
+docker pull cruizba/ubuntu-dind:latest
+
+# GitHub Container Registry
+docker pull ghcr.io/cruizba/ubuntu-dind:latest
+
+# Quay.io
+docker pull quay.io/cruizba/ubuntu-dind:latest
+```
 
 All tags are released in this format:
 


### PR DESCRIPTION
## Summary

- Add login steps for `ghcr.io` (using `GITHUB_TOKEN`) and `quay.io` (using `QUAY_USERNAME`/`QUAY_TOKEN` secrets) in the build workflow
- Push all image tags to all three registries: Docker Hub, ghcr.io, and quay.io
- Add `packages: write` permission to the job for ghcr.io access
- Update README section 5 with a registry table and pull examples for each registry
- Update release notes template in `version-bump.yml` to list all three registries